### PR TITLE
Fix InstallLibreELEC

### DIFF
--- a/LibreELEC/installLibreELEC
+++ b/LibreELEC/installLibreELEC
@@ -166,7 +166,7 @@ fi
 
 ####################  Now we start the actual work !...
 IMAGENAME="LibreELEC"
-FBVERSION="8.2.0.1"    # fallback LibreELEC version if latest can not be detected
+FBVERSION="9.0.2"    # fallback LibreELEC version if latest can not be detected
 BB_MEM="128"         # this corresponds to LibreELEC default 16MB gpu memory split. Change if you need different
 MODEL=""
 
@@ -223,7 +223,7 @@ case $resp in
 esac
 
 # Try to find latest LibreELEC version number
-VLATEST=$( curl -Ls --user-agent "fogent" "https://libreelec.tv/downloads" | grep -o 'LibreELEC-RPi2\.arm-.*\.tar' | head -n 1 | awk -F "-" '{print $7}' | sed "s/....$//g" )
+VLATEST=$( curl -Ls --user-agent "fogent" "http://archive.libreelec.tv/?C=N;O=D" | grep -o 'LibreELEC-'$MODEL'\.arm-.*\.[0-9]\.[0-9]\.tar' | head -n 1 | awk -F "-" '{print $5}' | sed "s/....$//g" )
 echo ""
 if [ -z "${VLATEST}" ]; then
   echo "Could not identify latest version, falling-back to version ${FBVERSION}"

--- a/LibreELEC/installLibreELEC
+++ b/LibreELEC/installLibreELEC
@@ -180,6 +180,9 @@ case $MODEL in
   armv7l)
     MODEL="Pi v2/v3"
   ;;
+  aarch64)
+    MODEL="Pi v4"
+  ;;
   *)
     MODEL=""
   ;;
@@ -188,9 +191,9 @@ esac
 echo ""
 if [ ! -z "${MODEL}" ]; then
   echo -n "We detected ${MODEL} model. Please hit [ENTER] to confirm,
-or type \"0\" for Pi Zero/v1, or \"2\" for Pi v2/v3: "
+or type \"0\" for Pi Zero/v1, or \"2\" for Pi v2/v3, or \"4\" for Pi v4: "
 else
-  echo -n "Unknown Pi Model. Please type \"0\" for Pi Zero/v1, or \"2\" for Pi v2/v3: "
+  echo -n "Unknown Pi Model. Please type \"0\" for Pi Zero/v1, or \"2\" for Pi v2/v3, or \"4\" for Pi v4: "
 fi
 
 read -n 1 resp
@@ -202,6 +205,9 @@ case $resp in
   2)
     MODEL="RPi2"
   ;;
+  4)
+    MODEL="RPi4"
+  ;;
   "")
     case $MODEL in
       "Pi Zero/v1")
@@ -209,6 +215,9 @@ case $resp in
       ;;
       "Pi v2/v3")
         MODEL="RPi2"
+      ;;
+      "Pi v4")
+        MODEL="RPi4"
       ;;
       "")
         echo "Could not determine proper Pi Model, quitting..."

--- a/LibreELEC/installLibreELEC
+++ b/LibreELEC/installLibreELEC
@@ -3,7 +3,7 @@
 # Source & license at https://github.com/macmpi/berryboot-scripts
 # Feel free to report any issue or comment there.
 
-INSTLEVERSION="1.2"
+INSTLEVERSION="1.3"
 
 BBINITURL="https://bit.ly/BBInitLibreELEC"    
 INSTLEURL="https://bit.ly/InstLibreELEC"  


### PR DESCRIPTION
- improve automated versions detection (as download page is changing); default is now 9.0.2
- getting ready for Pi4 release

closes https://github.com/macmpi/berryboot-scripts/issues/11